### PR TITLE
Create dev environment compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # common
 Utilities and bits shared by multiple other repos
+
+## Dev Compose File
+
+The file `docker-compose.dev.yaml` can be used to spin up a development/testing environment. It includes both Kafka and MariaDB, configured for easy use with application code **not** running in containers (i.e. when running/debugging from IDE). It also includes web-based DB (Adminer) and Kafka (Redpanda Console) clients.  
+
+To bring up the containers, run `docker compose -f docker-compose.dev.yaml up -d`. To tear everything down, run `docker compose -f docker-compose.dev.yaml down`.  
+
+The compose file defines a few port-forwards for development use, these will all be on your `localhost` when the containers are running:
+
+| Port | Name          | Use                                                                         |
+| ---- | ------------- | --------------------------------------------------------------------------- |
+| 9092 | Kafka Broker  | Kafka broker port for application use                                       |
+| 3306 | DB Server     | MariaDB connection port for application use and/or your preferred DB client |
+| 8080 | DB Console    | Access from your browser to access Adminer                                  |
+| 8081 | Kafka Console | Access from your browser to access Redpanda Console                         |
+
+None of the containers have persistent volumes, data will be lost on container restart.  
+
+Scripts (`.sh`, `.sql`, `.sql.gz`, `.sql.xz` and `.sql.zst`) in the `sql/` directory of this repo will be used to initialize the database when the container starts up.  

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,49 @@
+services:
+  kafka:
+    image: 'bitnami/kafka'
+    ports:
+    - '9092:9092'
+    environment:
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'true'
+      KAFKA_BROKER_ID: '1'
+    # KRaft settings
+      KAFKA_ENABLE_KRAFT: 'yes'
+      KAFKA_CFG_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CFG_NODE_ID: '1'
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: '1@127.0.0.1:9093'
+    # Connectivity settings
+      ALLOW_PLAINTEXT_LISTENER: 'yes'
+      KAFKA_CFG_LISTENERS: 'EXTERNAL://:9092,CONTROLLER://:9093,INTERNAL://:19092'
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,INTERNAL:PLAINTEXT'
+      KAFKA_CFG_ADVERTISED_LISTENERS: 'INTERNAL://kafka:19092,EXTERNAL://localhost:9092'
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: 'INTERNAL'
+
+  kafka-console:
+    image: 'docker.redpanda.com/vectorized/console:v2.1.1'
+    depends_on:
+    - 'kafka'
+    ports:
+    - '8081:8080'
+    environment:
+      KAFKA_BROKERS: 'kafka:19092'
+
+  db:
+    image: 'mariadb:latest'
+    ports:
+    - '3306:3306'
+    volumes:
+    # Files put in the sql/ directory of this repo will be executed on container startup
+    - './sql:/docker-entrypoint-initdb.d:ro'
+    environment:
+      MARIADB_ROOT_PASSWORD: 'root' # Super insecure, but this is just for dev use
+
+  adminer:
+    image: 'adminer:standalone'
+    depends_on:
+    - 'db'
+    ports:
+    - '8080:8080'
+    environment:
+      ADMINER_DESIGN: 'dracula'
+

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -37,6 +37,7 @@ services:
     - './sql:/docker-entrypoint-initdb.d:ro'
     environment:
       MARIADB_ROOT_PASSWORD: 'root' # Super insecure, but this is just for dev use
+      MARIADB_DATABASE: 'jds'
 
   adminer:
     image: 'adminer:standalone'

--- a/sql/.keep
+++ b/sql/.keep
@@ -1,0 +1,1 @@
+We will put database initialization scripts here once they are ready


### PR DESCRIPTION
- Create dev environment compose file with Kafka, MariaDB, Redpanda Console, and Adminer
- Configurations for easy dev/test use when running apps from IDE
- Empty directory created in repo for DB init scripts
- Updated readme with usage instructions

Closes #1 